### PR TITLE
Add 'Ubuntu Accomplishments' to awesome.yaml

### DIFF
--- a/awesome.yaml
+++ b/awesome.yaml
@@ -129,6 +129,9 @@ projects:
   - name: Quickgui
     description: A Flutter frontend for quickget and quickemu.
     github: quickgui/quickgui
+  - name: Ubuntu Accomplishsments
+    description: A gamification of contributions to Ubuntu and the Ubuntu Community
+    github: UbuntuAccomplishments/viewer
 
 more:
   - name: awesome


### PR DESCRIPTION
Add Ubuntu Accomplishments

Related URLs not added to `awesome.yaml`, cos there aren't any fields for them:
- https://ubuntu-accomplishments.org/
- https://snapcraft.io/ubuntu-accomplishments
- https://github.com/UbuntuAccomplishments